### PR TITLE
Improve folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,101 @@
 # Repositorio Base
+
 A ideia do repositorio é servir de base para novos projetos. Com todos os pacotes e depencias necessarias para iniciar da melhor forma. O projeto foi criado com Next.js e styled-components. Para configuração do projeto, foram instalados:
 
-  - ESLint
+- [ESLint](https://eslint.org/)
 
-  - Husky
+- [Husky](https://typicode.github.io/husky/#/)
 
-  - Conventional Commits
+- [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
 O arquivo main.yml foi criado para implementar a primeira rotina de CI. Até então só tem o Lint, mas o Vercel pode ser adicionado depois.
 
 A maior parte do repositorio está utilizando o yarn para administrar os pacotes, por isso as rotinas foram montadas com ele.
 
-
 ## 📋 Instalação Base
 
-    - Clonar repositorio
-    $ git clone https://github.com/carolandrade1/template_next_styled && cd template_next_styled
+1. Clonar repositorio
 
-    - Instalar dependencias
-    $ yarn install
+```
+git clone https://github.com/carolandrade1/template_next_styled && cd template_next_styled
+```
 
-    - Rodar aplicativo
-    $ yarn dev
+2. Instalar dependências
 
-    - Acesse http://localhost:3000/ e navegue pelo site
+```
+yarn install
+```
 
+3. Rodar aplicativo
+
+```
+yarn dev
+```
+
+4. Acesse http://localhost:3000/ e navegue pelo site
 
 ## 📦 Pacotes e dependencias, caso queira começar do zero.
 
-    - Next.js + styled-components
-    yarn create next-app --example with-styled-components
-    
-    - ESLint
-    yarn add eslint --dev
-    yarn run eslint --init
+- Next.js + styled-components
 
-    * adicionar no arquivo package.json na seção scripts:
-    "lint": "eslint --ignore-path .gitignore ."
-    "lint:fix": "eslint --fix --ignore-path .gitignore ."
+```
+yarn create next-app --example with-styled-components
+```
 
-    - Husky
-    yarn add husky -D
-    yarn prepare (depois de adicionar o prepare)
-    npx husky add .husky/pre-commit "yarn lint:fix
+- ESLint
 
-    * adicionar no arquivo package.json na seção scripts:
-    "prepare": "husky install"
+1. Instalar a lib
 
-    - Conventional Commits
-    npm install commitizen -g
-    commitizen init cz-conventional-changelog --yarn --dev --exact
+```
+yarn add eslint --dev
+yarn run eslint --init
+```
 
-    * adicionar no arquivo package.json na seção scripts:
-    "commit": "cz"
+2. Adicionar no arquivo package.json na seção scripts:
 
-    - Prop Types
-    npm install --save prop-types
+```
+"lint": "eslint --ignore-path .gitignore ."
+"lint:fix": "eslint --fix --ignore-path .gitignore ."
+```
+
+- Husky
+
+1. Instalar a lib
+
+```
+yarn add husky -D
+```
+
+2. Adicionar no arquivo package.json na seção scripts:
+
+```
+"prepare": "husky install"
+```
+
+3. Rodar no terminal:
+
+```
+yarn prepare
+npx husky add .husky/pre-commit "yarn lint:fix"
+```
+
+- Conventional Commits
+
+1. Instalar a lib
+
+```
+npm install commitizen -g
+commitizen init cz-conventional-changelog --yarn --dev --exact
+```
+
+2. Adicionar no arquivo package.json na seção scripts:
+
+```
+"commit": "cz"
+```
+
+- Prop Types
+
+```
+npm install --save prop-types
+```

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,20 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createGlobalStyle, ThemeProvider } from 'styled-components';
+import { ThemeProvider } from 'styled-components';
 
-const GlobalStyle = createGlobalStyle`
-  body {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-  }
-`;
-
-const theme = {
-  colors: {
-    primary: '#0070f3',
-  },
-};
+import GlobalStyle from '../src/theme/GlobalStyles';
+import { theme } from '../src/theme';
 
 export default function App({ Component, pageProps }) {
   return (

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,6 @@
 import React from 'react';
-import styled from 'styled-components';
 
-const Title = styled.h1`
-  font-size: 50px;
-  color: ${({ theme }) => theme.colors.primary};
-`;
+import Title from '../src/components/Title';
 
 export default function Home() {
   return <Title>My page</Title>;

--- a/src/components/Title.js
+++ b/src/components/Title.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+const Title = styled.h1`
+  font-size: 50px;
+  color: ${({ theme }) => theme.colors.primary};
+`;
+
+export default Title;

--- a/src/theme/GlobalStyles.js
+++ b/src/theme/GlobalStyles.js
@@ -1,0 +1,11 @@
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+`;
+
+export default GlobalStyle;

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,0 +1,7 @@
+export const theme = {
+  colors: {
+    primary: '#0070f3',
+  },
+};
+
+export default theme;

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -1,7 +1,6 @@
+// eslint-disable-next-line import/prefer-default-export
 export const theme = {
   colors: {
     primary: '#0070f3',
   },
 };
-
-export default theme;


### PR DESCRIPTION
- mover `theme` e `GlobalStyle` para `src/theme` 
Acabei deixando `theme` como `export` em vez de `export default` pra caso você queira criar outros temas (ex: darkTheme).

- criar a pasta `src/components` e mover o `Title` para lá

- mudei algumas coisas do README, mas sinta-se livre pra descartar essas sugestões.